### PR TITLE
Karma module fix

### DIFF
--- a/src/app/components/associateHome/associate-home/associate-home.component.html
+++ b/src/app/components/associateHome/associate-home/associate-home.component.html
@@ -2,7 +2,7 @@
   <ngb-accordion #acc="ngbAccordion" activeIds="ngb-panel-0">
     <ngb-panel title="Simple">
       <ng-template ngbPanelContent>
-        <ngb-timepicker  [meridian]="meridian"></ngb-timepicker>
+        <ngb-timepicker [(ngModel)]="time" [meridian]="meridian"></ngb-timepicker>
         <button class="btn btn-sm btn-outline-{{meridian ? 'success' : 'danger'}}" (click)="toggleMeridian()">
           Meridian - {{meridian ? "ON" : "OFF"}}
         </button>
@@ -15,7 +15,7 @@
         <span>&#9733; <b>Fancy</b> title &#9733;</span>
       </ng-template>
       <ng-template ngbPanelContent>
-        <ngb-timepicker [meridian]="meridian"></ngb-timepicker>
+        <ngb-timepicker [(ngModel)]="time" [meridian]="meridian"></ngb-timepicker>
         <button class="btn btn-sm btn-outline-{{meridian ? 'success' : 'danger'}}" (click)="toggleMeridian()">
           Meridian - {{meridian ? "ON" : "OFF"}}
         </button>
@@ -26,7 +26,7 @@
     <ngb-panel title="Third">
 
       <ng-template ngbPanelContent>
-        <ngb-timepicker [meridian]="meridian"></ngb-timepicker>
+        <ngb-timepicker [(ngModel)]="time" [meridian]="meridian"></ngb-timepicker>
         <button class="btn btn-sm btn-outline-{{meridian ? 'success' : 'danger'}}" (click)="toggleMeridian()">
           Meridian - {{meridian ? "ON" : "OFF"}}
         </button>

--- a/src/app/components/associateHome/associate-home/associate-home.component.html
+++ b/src/app/components/associateHome/associate-home/associate-home.component.html
@@ -2,7 +2,7 @@
   <ngb-accordion #acc="ngbAccordion" activeIds="ngb-panel-0">
     <ngb-panel title="Simple">
       <ng-template ngbPanelContent>
-        <ngb-timepicker [(ngModel)]="time" [meridian]="meridian"></ngb-timepicker>
+        <ngb-timepicker  [meridian]="meridian"></ngb-timepicker>
         <button class="btn btn-sm btn-outline-{{meridian ? 'success' : 'danger'}}" (click)="toggleMeridian()">
           Meridian - {{meridian ? "ON" : "OFF"}}
         </button>
@@ -15,7 +15,7 @@
         <span>&#9733; <b>Fancy</b> title &#9733;</span>
       </ng-template>
       <ng-template ngbPanelContent>
-        <ngb-timepicker [(ngModel)]="time" [meridian]="meridian"></ngb-timepicker>
+        <ngb-timepicker [meridian]="meridian"></ngb-timepicker>
         <button class="btn btn-sm btn-outline-{{meridian ? 'success' : 'danger'}}" (click)="toggleMeridian()">
           Meridian - {{meridian ? "ON" : "OFF"}}
         </button>
@@ -26,7 +26,7 @@
     <ngb-panel title="Third">
 
       <ng-template ngbPanelContent>
-        <ngb-timepicker [(ngModel)]="time" [meridian]="meridian"></ngb-timepicker>
+        <ngb-timepicker [meridian]="meridian"></ngb-timepicker>
         <button class="btn btn-sm btn-outline-{{meridian ? 'success' : 'danger'}}" (click)="toggleMeridian()">
           Meridian - {{meridian ? "ON" : "OFF"}}
         </button>

--- a/src/app/components/associateHome/associate-home/associate-home.component.spec.ts
+++ b/src/app/components/associateHome/associate-home/associate-home.component.spec.ts
@@ -1,6 +1,15 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AssociateHomeComponent } from './associate-home.component';
+import { NgbModule, NgbAccordionModule } from '@ng-bootstrap/ng-bootstrap';
+import { FormsModule } from '@angular/forms';
+
+// beforeEach( () => {
+//   TestBed.configureTestingModule({
+//     imports: [, ],
+//     declarations: []
+//   }).compileComponents();
+// });
 
 describe('AssociateHomeComponent', () => {
   let component: AssociateHomeComponent;

--- a/src/test.ts
+++ b/src/test.ts
@@ -6,14 +6,18 @@ import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
+import { FormsModule } from '@angular/forms';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { RouterTestingModule } from '@angular/router/testing';
 
 declare const require: any;
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  [BrowserDynamicTestingModule, RouterTestingModule, NgbModule, FormsModule],
+  platformBrowserDynamicTesting(),
 );
+
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.


### PR DESCRIPTION
Karma tests are not aware of declarations made in our app module, and instead run with their own module configuration.  This configuration is managed at `src/test.ts`.  It was not _only_ the bootstrap components that were failing - but also things using ngModel (dependent on the FormsModule) and the router-outlet tag (dependent on the RouterModule).

Initially, I added customization on this particular spec file to import these dependencies for those specific tests, but given a little more consideration I was able to centralize this configuration by modifying the base TestBed to import these Modules.  Note: Rather than the standard RouterModule, I'm instead using the RouterTestModule - a different module built for test cases.

With this unit tests and builds should be successful, so I've also integrated the travis-ci integration into this pull request.